### PR TITLE
Update version of rubyzip used to fix security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     rake_dependencies (0.18.0)
       hamster (~> 3.0)
       minitar (~> 0.6)
-      rubyzip (~> 1.1)
+      rubyzip (>= 1.2.2)
 
 GEM
   remote: https://rubygems.org/
@@ -24,7 +24,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    minitar (0.6.1)
+    minitar (0.7)
     minitest (5.11.3)
     rake (11.3.0)
     rspec (3.8.0)
@@ -64,4 +64,4 @@ DEPENDENCIES
   simplecov (~> 0.13)
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/rake_dependencies.gemspec
+++ b/rake_dependencies.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency 'hamster', '~> 3.0'
-  spec.add_dependency 'rubyzip', '~> 1.1'
+  spec.add_dependency 'rubyzip', '>= 1.2.2'
   spec.add_dependency 'minitar', '~> 0.6'
 
   spec.add_development_dependency 'bundler', '~> 1.14'


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000544